### PR TITLE
Migliorie alla gestione della trivella

### DIFF
--- a/SpaceEngeneersQOL/DrillManagement/Trivella.cs
+++ b/SpaceEngeneersQOL/DrillManagement/Trivella.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Configuration;
 using System.Linq;
 using System.Text;
 using VRage;
@@ -20,251 +21,242 @@ using VRageMath;
 
 namespace IngameScript.DrillManagement
 {
-  public class Program : MyGridProgram
-  {
-    /* 
-     * Questo script gestisce l'avanzamento verticale di una trivella rotante
-     * per poter funzionare ha bisogno di trovare alcuni componenti, procedere come segue:
-     * 1. Mettere i nomi corretti per i seguenti componenti:
-     *    PistonGroupName      =>  Nome del gruppo che include tutti i pistoni verticali che spingono le trivelle
-     *    DrillsGroupName      =>  Nome del gruppo che include tutte le trivelle 
-     *    DrillRotorName       =>  Nome del rotore che fa ruotare la trivella
-     *    DrillDebugLightName  =>  Nome della luce da accendere quando c'è un problema
-     *    DrillLcdPanelName    =>  (opzionale) Nome del componente LCD su cui scrivere l'avanzamento.
-     * 2. Controllare il metodo `getPistonIndexFromName` ed eventualmente modificarlo per ottenere 
-     *    un criterio di ordinamento per i pistoni verticali, sarà l'ordine con cui vengono estesi
-     */
-    private readonly string PistonGroupName = "Trivella.Pistons";
-    private readonly string DrillsGroupName = "Trivella.Drills";
-    private readonly string DrillRotorName = "Trivella.Rotor";
-    private readonly string DrillDebugLightName = "Trivella.DebugLight";
-    /* 
-     * Pannello LCD su cui scrivere lo stato di avanzamento:
-     * se non lo trova usa il pannello principale del blocco program
-     */
-    private readonly string DrillLcdPanelName = "Trivella.TextPanel";
-    /* 
-     * Funzione che restituisce un indice a partire dal nome del pistone,
-     * questo indice influenzerà l'ordine di estensione dei pistoni
-     */
-    private readonly Func<string, int> getPistonIndexFromName = (string text) =>
+    public class Program : MyGridProgram
     {
-      var match = new System.Text.RegularExpressions.Regex(@"^.*-(?<index>\d+)$").Match(text);
-      return match.Success ? int.Parse(match.Groups["index"].Value) : 0;
-    };
+        /*
+         * Questo script gestisce l'avanzamento verticale di una trivella rotante
+         * per poter funzionare ha bisogno di trovare alcuni componenti, procedere come segue:
+         * 1. Mettere i nomi corretti per i seguenti componenti:
+         *    PistonGroupName      =>  Nome del gruppo che include tutti i pistoni verticali che spingono le trivelle
+         *    DrillsGroupName      =>  Nome del gruppo che include tutte le trivelle
+         *    DrillRotorName       =>  Nome del rotore che fa ruotare la trivella
+         *    DrillDebugLightName  =>  Nome della luce da accendere quando c'è un problema
+         *    DrillLcdPanelName    =>  (opzionale) Nome del componente LCD su cui scrivere l'avanzamento.
+         * 2. Controllare il metodo `getPistonIndexFromName` ed eventualmente modificarlo per ottenere
+         *    un criterio di ordinamento per i pistoni verticali, sarà l'ordine con cui vengono estesi
+         */
+        static class Config
+        {
+            public static readonly string PistonGroupName = "Trivella.Pistons";
+            public static readonly string DrillsGroupName = "Trivella.Drills";
+            public static readonly string DrillRotorName = "Trivella.Rotor";
+            public static readonly string DrillDebugLightName = "Trivella.DebugLight";
+            /*
+             * Pannello LCD su cui scrivere lo stato di avanzamento:
+             * se non lo trova usa il pannello principale del blocco program
+             */
+            public static readonly string DrillLcdPanelName = "Trivella.TextPanel";
+            /*
+             * Funzione che restituisce un indice a partire dal nome del pistone,
+             * questo indice influenzerà l'ordine di estensione dei pistoni
+             */
+            public static readonly System.Text.RegularExpressions.Regex FindIndexRegex =
+              // la regular expression utilizata deve restituire un `Named Group` chiamato "index" con all'interno l'indice da usare
+              // la regular expression usata è questa: `^.*(?<index>\d+)$`
+              // che tradotta in italiano significa: trova qualunque gruppo di numeri che sia alla fine della stringa e che sia preceduto da
+              // un numero indefinito di caratteri qualunque a partire dal primo e chiamalo "index"
+              new System.Text.RegularExpressions.Regex(@"^.*(?<index>\d+)$");
+        }
 
-    private readonly float angleThreshold = 0.1f;
-    private readonly float fillThreshold = 0.9f;
-    private float nextTargetAngle = 0.0f;
-    public Program()
-    {
-      Runtime.UpdateFrequency = UpdateFrequency.Update10;
-    }
+        private readonly float angleThreshold = 0.1f;
+        private readonly float fillThreshold = 0.9f;
+        private float nextTargetAngle = 0.0f;
+        private IMyTextSurface logDisplay;
+        private int getPistonIndexFromName(string text)
+        {
+            var match = Config.FindIndexRegex.Match(text);
+            return match.Success ? int.Parse(match.Groups["index"].Value) : 0;
+        }
+        public Program()
+        {
+            Runtime.UpdateFrequency = UpdateFrequency.Update10;
+        }
 
-    private float GetReachableCargoFillRatio(VRage.Game.ModAPI.Ingame.IMyInventory referenceInventory)
-    {
-
-      List<IMyTerminalBlock> blocks = new List<IMyTerminalBlock> { };
-      GridTerminalSystem.GetBlocks(blocks);
-
-      var blocksInTheGrid = blocks
-          .Where((block) =>
-              block.IsSameConstructAs(Me) &&
-              block.GetInventory() != null &&
+        private float GetReachableCargoFillRatio(VRage.Game.ModAPI.Ingame.IMyInventory referenceInventory)
+        {
+            List<IMyInventoryOwner> blocksInTheGrid = new List<IMyInventoryOwner>();
+            GridTerminalSystem.GetBlocksOfType(blocksInTheGrid, (block) =>
+              block.HasInventory &&
               referenceInventory != null &&
-              referenceInventory.IsConnectedTo(block.GetInventory())
-          );
+              referenceInventory.IsConnectedTo(block.GetInventory(block.InventoryCount - 1))
+            );
+            Echo("Connected Inventory owners: " + blocksInTheGrid.Count.ToString());
 
-      var currentTotalVolume = 0.0f;
-      var maxTotalVolume = 0.0f;
+            var currentTotalVolume = 0.0f;
+            var maxTotalVolume = 0.0f;
 
-      foreach (var block in blocksInTheGrid)
-      {
-        var inventory = block.GetInventory();
-        currentTotalVolume += (float)inventory.CurrentVolume;
-        maxTotalVolume += (float)inventory.MaxVolume;
-      }
+            foreach (var block in blocksInTheGrid)
+            {
+                var inventory = block.GetInventory(block.InventoryCount - 1);
+                currentTotalVolume += (float)inventory.CurrentVolume;
+                maxTotalVolume += (float)inventory.MaxVolume;
+            }
 
-      var totalFillRatio = currentTotalVolume / maxTotalVolume;
+            var totalFillRatio = currentTotalVolume / maxTotalVolume;
 
-      return totalFillRatio;
-    }
-
-
-    private bool CheckExistence(Object entity, IMyTextSurface output, String entityName)
-    {
-      if (output == null)
-      {
-        Echo("no output for debugging");
-        return false;
-      }
-
-      if (entity == null)
-      {
-        output.WriteText($"[CFG ERR]: entity not found: {entityName}");
-
-        return false;
-      }
-
-      return true;
-    }
-
-    private bool HasCompletedFullTurn(IMyMotorStator rotor)
-    {
-      return rotor.Angle < nextTargetAngle + angleThreshold && rotor.Angle >= nextTargetAngle - angleThreshold;
-    }
-
-    private void TurnOn(IMyTerminalBlock entity)
-    {
-      if (entity != null)
-      {
-        entity.ApplyAction("OnOff_On");
-      }
-    }
-
-    private void TurnOnGroup(IMyBlockGroup entities)
-    {
-      if (entities != null)
-      {
-        var children = new List<IMyTerminalBlock> { };
-        entities.GetBlocks(children);
-        foreach (var block in children)
-        {
-          block.ApplyAction("OnOff_On");
+            return totalFillRatio;
         }
-      }
-    }
 
-    private void TurnOff(IMyTerminalBlock entity)
-    {
-      entity?.ApplyAction("OnOff_Off");
-    }
-    private void TurnOffGroup(IMyBlockGroup entities)
-    {
-      if (entities != null)
-      {
-        var children = new List<IMyTerminalBlock> { };
-        entities.GetBlocks(children);
-        foreach (var block in children)
+        private bool CheckExistence(object entity, string entityName)
         {
-          block.ApplyAction("OnOff_Off");
+            if (logDisplay == null)
+            {
+                Echo("no output for debugging");
+                return false;
+            }
+
+            if (entity == null)
+            {
+                logDisplay.WriteText($"[CFG ERR]: entity not found: {entityName}");
+                return false;
+            }
+
+            return true;
         }
-      }
-    }
 
-    private void TurnOffObject(object node) {
-      if (node is IMyBlockGroup) {
-        TurnOffGroup(node as IMyBlockGroup);
-      } else {
-        TurnOff(node as IMyTerminalBlock);
-      }
-    }
-    private void TurnOnObject(object node) {
-      if (node is IMyBlockGroup) {
-        TurnOnGroup(node as IMyBlockGroup);
-      } else {
-        TurnOn(node as IMyTerminalBlock);
-      }
-    }
-
-    private void IncreaseMaxDistanceAndMove(IMyPistonBase piston)
-    {
-      piston.ApplyAction("IncreaseUpperLimit");
-      piston.ApplyAction("Extend");
-    }
-
-    private void LogPistonPosition(IMyTextSurface lcd, IMyPistonBase current, List<IMyPistonBase> pistons)
-    {
-      pistons.ForEach((piston) =>
-      {
-        var currentFlag = current.EntityId == piston.EntityId ? "> " : "";
-        lcd.WriteText($"{currentFlag}{piston.CustomName} at {piston.CurrentPosition} / {piston.MaxLimit} | {piston.HighestPosition}\n", true);
-      });
-    }
-
-    private bool assertConfig(IMyTextSurface lcd,object pistons,object drills,object rotor,object light) {
-      if (!CheckExistence(pistons, lcd, "Pistons Group")) return false;
-      if (!CheckExistence(drills, lcd, "Drills Group")) return false;
-      if (!CheckExistence(rotor, lcd, "Rotor")) return false;
-      if (!CheckExistence(light, lcd, "Light")) return false;
-      return true;
-    }
-    public void Main(string argument, UpdateType updateSource)
-    {
-      var pistons = GridTerminalSystem.GetBlockGroupWithName(PistonGroupName);
-      var drills = GridTerminalSystem.GetBlockGroupWithName(DrillsGroupName);
-      var rotor = GridTerminalSystem.GetBlockWithName(DrillRotorName) as IMyMotorStator;
-      object light = GridTerminalSystem.GetBlockWithName(DrillDebugLightName);
-      if (light == null) { light = GridTerminalSystem.GetBlockGroupWithName(DrillDebugLightName); }
-      var lcd = GridTerminalSystem.GetBlockWithName(DrillLcdPanelName) as IMyTextSurface ?? Me.GetSurface(0);
-
-      if (!assertConfig(lcd, pistons, drills, rotor, light)) return;
-
-      TurnOffObject(light);
-
-      var pistonsBlockList = new List<IMyPistonBase> { };
-      var drillsBlockList = new List<IMyTerminalBlock> { };
-
-      pistons.GetBlocksOfType(pistonsBlockList);
-      drills.GetBlocksOfType(drillsBlockList);
-
-      Echo("Pistons Found: " + pistonsBlockList.Count);
-      Echo("Drill Found: " + drillsBlockList.Count);
-
-      // select current piston (ordered by the number in the name)
-      var sortedPistons = pistonsBlockList
-          .Where((pistonBlock) => pistonBlock.MaxLimit < pistonBlock.HighestPosition)
-          .OrderBy((pistonBlock) => getPistonIndexFromName(pistonBlock.CustomName))
-          .ToList();
-      Echo("Not Extended pistons: " + sortedPistons.Count);
-      if (sortedPistons.Count == 0)
-      {
-        Echo("All pistons are fully extended! Exiting.");
-        TurnOnObject(light);
-        return;
-      }
-      var currentPiston = sortedPistons[0];
-
-      var fillRatio = GetReachableCargoFillRatio(drillsBlockList[0].GetInventory());
-
-      if (fillRatio > fillThreshold)
-      {
-        // storage is full, shut everything down
-        drillsBlockList.ForEach((drillBlock) =>
+        private bool HasCompletedFullTurn(IMyMotorStator rotor)
         {
-          TurnOff(drillBlock);
-          TurnOff(rotor);
-        });
-      }
-      else
-      {
-        drillsBlockList.ForEach((drillBlock) =>
+            return rotor.Angle < nextTargetAngle + angleThreshold && rotor.Angle >= nextTargetAngle - angleThreshold;
+        }
+
+        private void TurnOn(object entity)
         {
-          TurnOn(drillBlock);
-        });
-        TurnOn(rotor);
-      }
+            if (entity is IMyTerminalBlock)
+            {
+                (entity as IMyTerminalBlock).ApplyAction("OnOff_On");
+            }
+            else if (entity is IMyBlockGroup)
+            {
+                var children = new List<IMyTerminalBlock>();
+                (entity as IMyBlockGroup).GetBlocks(children);
+                foreach (var block in children)
+                {
+                    block.ApplyAction("OnOff_On");
+                }
+            }
+        }
 
-      if (HasCompletedFullTurn(rotor))
-      {
-        if (nextTargetAngle == 0) nextTargetAngle = 3.14f;
-        else nextTargetAngle = 0;
-        TurnOnObject(light);
-        IncreaseMaxDistanceAndMove(currentPiston);
-      }
-      else
-      {
-        TurnOffObject(light);
-      }
+        private void TurnOff(object entity)
+        {
+            if (entity is IMyTerminalBlock)
+            {
+                (entity as IMyTerminalBlock).ApplyAction("OnOff_Off");
+            }
+            else if (entity is IMyBlockGroup)
+            {
+                var children = new List<IMyTerminalBlock>();
+                (entity as IMyBlockGroup).GetBlocks(children);
+                foreach (var block in children)
+                {
+                    block.ApplyAction("OnOff_Off");
+                }
+            }
+        }
 
-      lcd.WriteText($"current angle: {rotor.Angle}\n");
-      lcd.WriteText($"station capacity at {(fillRatio * 100).ToString("0.00")}%\n\n", true);
+        private void IncreaseMaxDistanceAndMove(IMyPistonBase piston)
+        {
+            piston.ApplyAction("IncreaseUpperLimit");
+            piston.ApplyAction("Extend");
+        }
 
-      LogPistonPosition(lcd, currentPiston, pistonsBlockList);
+        private void LogPistonPosition(IMyPistonBase current, List<IMyPistonBase> pistons)
+        {
+            pistons.ForEach((piston) =>
+            {
+                var currentFlag = current?.EntityId == piston.EntityId ? "> " : "";
+                logDisplay.WriteText($"{currentFlag}{piston.CustomName} at {piston.CurrentPosition} / {piston.MaxLimit} | {piston.HighestPosition}\n", true);
+            });
+        }
+
+        private bool AssertConfig(object pistons, object drills, object rotor, object light)
+        {
+            if (!CheckExistence(pistons, "Pistons Group")) return false;
+            if (!CheckExistence(drills, "Drills Group")) return false;
+            if (!CheckExistence(rotor, "Rotor")) return false;
+            if (!CheckExistence(light, "Light")) return false;
+            return true;
+        }
+        public void Main(string argument, UpdateType updateSource)
+        {
+            var pistons = GridTerminalSystem.GetBlockGroupWithName(Config.PistonGroupName);
+            var drills = GridTerminalSystem.GetBlockGroupWithName(Config.DrillsGroupName);
+            var rotor = GridTerminalSystem.GetBlockWithName(Config.DrillRotorName) as IMyMotorStator;
+            object light = GridTerminalSystem.GetBlockWithName(Config.DrillDebugLightName);
+            if (light == null) { light = GridTerminalSystem.GetBlockGroupWithName(Config.DrillDebugLightName); }
+            logDisplay = GridTerminalSystem.GetBlockWithName(Config.DrillLcdPanelName) as IMyTextSurface ?? Me.GetSurface(0);
+
+            if (!AssertConfig(pistons, drills, rotor, light)) return;
+
+            TurnOff(light);
+
+            var pistonsBlockList = new List<IMyPistonBase> { };
+            var drillsBlockList = new List<IMyTerminalBlock> { };
+
+            pistons.GetBlocksOfType(pistonsBlockList);
+            drills.GetBlocksOfType(drillsBlockList);
+
+            Echo("Pistons Found: " + pistonsBlockList.Count);
+            Echo("Drill Found: " + drillsBlockList.Count);
+
+            // select current piston (ordered by the number in the name)
+            var sortedPistons = pistonsBlockList
+                .Where((pistonBlock) => pistonBlock.CurrentPosition < pistonBlock.HighestPosition)
+                .OrderBy((pistonBlock) => getPistonIndexFromName(pistonBlock.CustomName));
+            var pistonCount = sortedPistons.Count();
+            Echo($"Not Extended pistons: {pistonCount}");
+            if (pistonCount == 0)
+            {
+                Echo("All pistons are fully extended! Exiting.");
+                TurnOn(light);
+                LogPistonPosition(null, pistonsBlockList);
+                return;
+            }
+            var currentPiston = sortedPistons.First();
+            LogPistonPosition(currentPiston, pistonsBlockList);
+
+            var referenceInventory = drillsBlockList[0].GetInventory(0);
+            Echo($"Reference inventory: {drillsBlockList[0].CustomName}");
+
+            var fillRatio = GetReachableCargoFillRatio(referenceInventory);
+
+            if (fillRatio > fillThreshold)
+            {
+                // storage is full, shut everything down
+                drillsBlockList.ForEach((drillBlock) =>
+                {
+                    TurnOff(drillBlock);
+                    TurnOff(rotor);
+                });
+            }
+            else
+            {
+                drillsBlockList.ForEach((drillBlock) =>
+                {
+                    TurnOn(drillBlock);
+                });
+                TurnOn(rotor);
+            }
+
+            if (HasCompletedFullTurn(rotor))
+            {
+                if (nextTargetAngle == 0) nextTargetAngle = 3.14f;
+                else nextTargetAngle = 0;
+                TurnOn(light);
+                IncreaseMaxDistanceAndMove(currentPiston);
+            }
+            else
+            {
+                TurnOff(light);
+            }
+
+            logDisplay.WriteText($"current angle: {rotor.Angle}\n");
+            logDisplay.WriteText($"station capacity at {(fillRatio * 100).ToString("0.00")}%\n\n", true);
+
+        }
+
+        public void Save()
+        {
+            // Method intentionally left empty.
+        }
     }
-    public void Save()
-    {
-      // Method intentionally left empty.
-    }
-  }
 }

--- a/SpaceEngeneersQOL/DrillManagement/Trivella.cs
+++ b/SpaceEngeneersQOL/DrillManagement/Trivella.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox.Game.EntityComponents;
+using Sandbox.Game.EntityComponents;
 using Sandbox.ModAPI.Ingame;
 using Sandbox.ModAPI.Interfaces;
 using SpaceEngineers.Game.ModAPI.Ingame;
@@ -18,167 +18,218 @@ using VRage.Game.ModAPI.Ingame.Utilities;
 using VRage.Game.ObjectBuilders.Definitions;
 using VRageMath;
 
-namespace SpaceEngeneersQOL.DrillManagement
+namespace IngameScript.DrillManagement
 {
-    partial class Trivella : MyGridProgram
+  public class Program : MyGridProgram
+  {
+    /* 
+     * Questo script gestisce l'avanzamento verticale di una trivella rotante
+     * per poter funzionare ha bisogno di trovare alcuni componenti, procedere come segue:
+     * 1. Mettere i nomi corretti per i seguenti componenti:
+     *    PistonGroupName      =>  Nome del gruppo che include tutti i pistoni verticali che spingono le trivelle
+     *    DrillsGroupName      =>  Nome del gruppo che include tutte le trivelle 
+     *    DrillRotorName       =>  Nome del rotore che fa ruotare la trivella
+     *    DrillDebugLightName  =>  Nome della luce da accendere quando c'è un problema
+     *    DrillLcdPanelName    =>  (opzionale) Nome del componente LCD su cui scrivere l'avanzamento.
+     * 2. Controllare il metodo `getPistonIndexFromName` ed eventualmente modificarlo per ottenere 
+     *    un criterio di ordinamento per i pistoni verticali, sarà l'ordine con cui vengono estesi
+     */
+    private readonly string PistonGroupName = "Trivella.Pistons";
+    private readonly string DrillsGroupName = "Trivella.Drills";
+    private readonly string DrillRotorName = "Trivella.Rotor";
+    private readonly string DrillDebugLightName = "Trivella.DebugLight";
+    /* 
+     * Pannello LCD su cui scrivere lo stato di avanzamento:
+     * se non lo trova usa il pannello principale del blocco program
+     */
+    private readonly string DrillLcdPanelName = "Trivella.TextPanel";
+    /* 
+     * Funzione che restituisce un indice a partire dal nome del pistone,
+     * questo indice influenzerà l'ordine di estensione dei pistoni
+     */
+    private readonly Func<string, int> getPistonIndexFromName = (string text) =>
     {
-        private readonly float angleThreshold = 0.1f;
-        private readonly float fillThreshold = 0.9f;
-        private float nextTargetAngle = 0.0f;
+      var match = new System.Text.RegularExpressions.Regex(@"^.*-(?<index>\d+)$").Match(text);
+      return match.Success ? int.Parse(match.Groups["index"].Value) : 0;
+    };
 
-        public Trivella()
-        {
-            Runtime.UpdateFrequency = UpdateFrequency.Update10;
-        }
-
-        private float GetReachableCargoFillRatio(VRage.Game.ModAPI.Ingame.IMyInventory referenceInventory)
-        {
-
-            List<IMyTerminalBlock> blocks = new List<IMyTerminalBlock> { };
-            GridTerminalSystem.GetBlocks(blocks);
-
-            var blocksInTheGrid = blocks
-                .Where((block) =>
-                    block.IsSameConstructAs(Me) &&
-                    block.GetInventory() != null &&
-                    referenceInventory.IsConnectedTo(block.GetInventory())
-                );
-
-            var currentTotalVolume = 0.0f;
-            var maxTotalVolume = 0.0f;
-
-            foreach (var block in blocksInTheGrid)
-            {
-                var inventory = block.GetInventory();
-                currentTotalVolume += ((float)inventory.CurrentVolume);
-                maxTotalVolume += ((float)inventory.MaxVolume);
-            }
-
-            var totalFillRatio = currentTotalVolume / maxTotalVolume;
-
-            return totalFillRatio;
-        }
-
-        private bool CheckExistence(Object entity, IMyTextPanel output, String entityName)
-        {
-            if (output == null)
-            {
-                Echo("no output for debugging");
-                return false;
-            }
-
-            if (entity == null)
-            {
-                output.WriteText($"[color='#FF0000'] entity not found: {entityName}");
-
-                return false;
-            }
-
-            return true;
-        }
-
-        private bool HasCompletedFullTurn(IMyMotorStator rotor)
-        {
-            return rotor.Angle < nextTargetAngle + angleThreshold && rotor.Angle >= nextTargetAngle - angleThreshold;
-        }
-
-        private bool TurnOn(IMyTerminalBlock entity)
-        {
-            if (entity != null)
-            {
-                entity.ApplyAction("OnOff_On");
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TurnOff(IMyTerminalBlock entity)
-        {
-            if (entity != null)
-            {
-                entity.ApplyAction("OnOff_Off");
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void IncreaseMaxDistanceAndMove(IMyPistonBase piston)
-        {
-            piston.ApplyAction("IncreaseUpperLimit");
-            piston.ApplyAction("Extend");
-        }
-
-        public void Main(string argument, UpdateType updateSource)
-        {
-            var pistons = GridTerminalSystem.GetBlockGroupWithName("Trivella.Pistons");
-            var drills = GridTerminalSystem.GetBlockGroupWithName("Trivella.Drills");
-            var rotor = GridTerminalSystem.GetBlockWithName("Trivella.Rotor") as IMyMotorStator;
-            var light = GridTerminalSystem.GetBlockWithName("Trivella.DebugLight");
-            var lcd = GridTerminalSystem.GetBlockWithName("Trivella.TextPanel") as IMyTextPanel;
-
-            if (!CheckExistence(pistons, lcd, "Pistons Group")) return;
-            if (!CheckExistence(drills, lcd, "Drills Group")) return;
-            if (!CheckExistence(rotor, lcd, "Rotor")) return;
-            if (!CheckExistence(light, lcd, "Light")) return;
-
-            var pistonsBlockList = new List<IMyTerminalBlock> { };
-            var drillsBlockList = new List<IMyTerminalBlock> { };
-
-            pistons.GetBlocks(pistonsBlockList);
-            drills.GetBlocks(drillsBlockList);
-
-            lcd.SetValue("FontColor", Color.Green);
-
-            // select current piston (ordered by the number in the name)
-            var currentPiston = pistonsBlockList
-                .Where((pistonBlock) => (pistonBlock as IMyPistonBase).MaxLimit < (pistonBlock as IMyPistonBase).HighestPosition)
-                .OrderBy((pistonBlock) => float.Parse(pistonBlock.CustomName.Split(' ')[1]))
-                .ToList()
-                .First();
-            var fillRatio = GetReachableCargoFillRatio(drillsBlockList[0].GetInventory());
-
-            if (fillRatio > fillThreshold)
-            {
-                // storage is full, shut everything down
-                drillsBlockList.ForEach((drillBlock) =>
-                {
-                    TurnOff(drillBlock);
-                    TurnOff(rotor);
-                });
-            }
-            else
-            {
-                drillsBlockList.ForEach((drillBlock) =>
-                {
-                    TurnOn(drillBlock);
-                });
-                TurnOn(rotor);
-            }
-
-            if (HasCompletedFullTurn(rotor))
-            {
-                if (nextTargetAngle == 0) nextTargetAngle = 3.14f;
-                else nextTargetAngle = 0;
-                TurnOn(light);
-                IncreaseMaxDistanceAndMove(currentPiston as IMyPistonBase);
-            }
-            else
-            {
-                TurnOff(light);
-            }
-
-            lcd.WriteText($"current angle: {rotor.Angle}\n");
-            lcd.WriteText($"station capacity at {(fillRatio * 100).ToString("0.00")}%\n\n", true);
-
-            pistonsBlockList.ForEach((pistonBlock) =>
-            {
-                lcd.WriteText($"{(pistonBlock.EntityId == currentPiston.EntityId ? "> " : "")}{pistonBlock.CustomName} at {(pistonBlock as IMyPistonBase).CurrentPosition} / {(pistonBlock as IMyPistonBase).MaxLimit} | {(pistonBlock as IMyPistonBase).HighestPosition}\n", true);
-            });
-        }
-
+    private readonly float angleThreshold = 0.1f;
+    private readonly float fillThreshold = 0.9f;
+    private float nextTargetAngle = 0.0f;
+    public Program()
+    {
+      Runtime.UpdateFrequency = UpdateFrequency.Update10;
     }
+    
+    private float GetReachableCargoFillRatio(VRage.Game.ModAPI.Ingame.IMyInventory referenceInventory)
+    {
+
+      List<IMyTerminalBlock> blocks = new List<IMyTerminalBlock> { };
+      GridTerminalSystem.GetBlocks(blocks);
+
+      var blocksInTheGrid = blocks
+          .Where((block) =>
+              block.IsSameConstructAs(Me) &&
+              block.GetInventory() != null &&
+              referenceInventory != null &&
+              referenceInventory.IsConnectedTo(block.GetInventory())
+          );
+
+      var currentTotalVolume = 0.0f;
+      var maxTotalVolume = 0.0f;
+
+      foreach (var block in blocksInTheGrid)
+      {
+        var inventory = block.GetInventory();
+        currentTotalVolume += (float)inventory.CurrentVolume;
+        maxTotalVolume += (float)inventory.MaxVolume;
+      }
+
+      var totalFillRatio = currentTotalVolume / maxTotalVolume;
+
+      return totalFillRatio;
+    }
+
+
+    private bool CheckExistence(Object entity, IMyTextPanel output, String entityName)
+    {
+      if (output == null)
+      {
+        Echo("no output for debugging");
+        return false;
+      }
+
+      if (entity == null)
+      {
+        output.WriteText($"[color='#FF0000'] entity not found: {entityName}");
+
+        return false;
+      }
+
+      return true;
+    }
+
+    private bool HasCompletedFullTurn(IMyMotorStator rotor)
+    {
+      return rotor.Angle < nextTargetAngle + angleThreshold && rotor.Angle >= nextTargetAngle - angleThreshold;
+    }
+
+    private bool TurnOn(IMyTerminalBlock entity)
+    {
+      if (entity != null)
+      {
+        entity.ApplyAction("OnOff_On");
+
+        return true;
+      }
+
+      return false;
+    }
+
+    private bool TurnOff(IMyTerminalBlock entity)
+    {
+      if (entity != null)
+      {
+        entity.ApplyAction("OnOff_Off");
+
+        return true;
+      }
+
+      return false;
+    }
+
+    private void IncreaseMaxDistanceAndMove(IMyPistonBase piston)
+    {
+      piston.ApplyAction("IncreaseUpperLimit");
+      piston.ApplyAction("Extend");
+    }
+
+    private void LogPistonPosition(IMyTextPanel lcd, IMyPistonBase current, List<IMyPistonBase> pistons)
+    {
+      pistons.ForEach((piston) =>{
+        var currentFlag = current.EntityId == piston.EntityId ? "> " : "";
+        lcd.WriteText($"{currentFlag}{piston.CustomName} at {piston.CurrentPosition} / {piston.MaxLimit} | {piston.HighestPosition}\n", true);
+      });
+    }
+    public void Main(string argument, UpdateType updateSource)
+    {
+      var pistons = GridTerminalSystem.GetBlockGroupWithName(PistonGroupName);
+      var drills = GridTerminalSystem.GetBlockGroupWithName(DrillsGroupName);
+      var rotor = GridTerminalSystem.GetBlockWithName(DrillRotorName) as IMyMotorStator;
+      var light = GridTerminalSystem.GetBlockWithName(DrillDebugLightName);
+      var lcd = GridTerminalSystem.GetBlockWithName(DrillLcdPanelName) as IMyTextPanel ?? Me.GetSurface(0) as IMyTextPanel;
+
+      if (!CheckExistence(pistons, lcd, "Pistons Group")) return;
+      if (!CheckExistence(drills, lcd, "Drills Group")) return;
+      if (!CheckExistence(rotor, lcd, "Rotor")) return;
+      if (!CheckExistence(light, lcd, "Light")) return;
+
+      var pistonsBlockList = new List<IMyPistonBase> { };
+      var drillsBlockList = new List<IMyTerminalBlock> { };
+
+      pistons.GetBlocksOfType(pistonsBlockList);
+      drills.GetBlocksOfType(drillsBlockList);
+
+      Echo("Pistons Found: " + pistonsBlockList.Count);
+      Echo("Drill Found: " + drillsBlockList.Count);
+
+      lcd.SetValue("FontColor", Color.Green);
+
+      // select current piston (ordered by the number in the name)
+      var sortedPistons = pistonsBlockList
+          .Where((pistonBlock) => pistonBlock.MaxLimit < pistonBlock.HighestPosition)
+          .OrderBy((pistonBlock) => getPistonIndexFromName(pistonBlock.CustomName))
+          .ToList();
+      Echo("Not Extended pistons: " + sortedPistons.Count);
+      if (sortedPistons.Count == 0)
+      {
+        Echo("All pistons are fully extended! Exiting.");
+        return;
+      }
+      var currentPiston = sortedPistons[0];
+
+      var fillRatio = GetReachableCargoFillRatio(drillsBlockList[0].GetInventory());
+
+      if (fillRatio > fillThreshold)
+      {
+        // storage is full, shut everything down
+        drillsBlockList.ForEach((drillBlock) =>
+        {
+          TurnOff(drillBlock);
+          TurnOff(rotor);
+        });
+      }
+      else
+      {
+        drillsBlockList.ForEach((drillBlock) =>
+        {
+          TurnOn(drillBlock);
+        });
+        TurnOn(rotor);
+      }
+      Echo("I am here");
+
+      if (HasCompletedFullTurn(rotor))
+      {
+        if (nextTargetAngle == 0) nextTargetAngle = 3.14f;
+        else nextTargetAngle = 0;
+        TurnOn(light);
+        IncreaseMaxDistanceAndMove(currentPiston);
+      }
+      else
+      {
+        TurnOff(light);
+      }
+
+      lcd.WriteText($"current angle: {rotor.Angle}\n");
+      lcd.WriteText($"station capacity at {(fillRatio * 100).ToString("0.00")}%\n\n", true);
+
+      LogPistonPosition(lcd, currentPiston, pistonsBlockList);
+    }
+
+    public void Save()
+    {
+      // Method intentionally left empty.
+    }
+  }
 }


### PR DESCRIPTION
# Migliorie alla gestione della trivella

Con questa modifica:

- si usa il pannello LCD del blocco program se il pannello LCD indicato non viene trovato.
- si usa una funzione specifica per recuperare l'index dei pistoni così
- si blocca l'esecuzione se non ci sono più pistoni da estendere

inoltre:

- migliorato il filtro `referenceInventory != null` per il calcolo della capienza
- `pistonsBlockList` ora usa il tipo `List<IMyPistonBase>` grazie a `GetBlocksOfType`
